### PR TITLE
Update build toolchains to support rewrapper from chroot.

### DIFF
--- a/reclient_cfgs/README.md
+++ b/reclient_cfgs/README.md
@@ -1,0 +1,1 @@
+This directory contains the config files accepted by re-client's rewrapper command in place of inline flags.

--- a/reclient_cfgs/rewrapper_chroot_compile.cfg
+++ b/reclient_cfgs/rewrapper_chroot_compile.cfg
@@ -1,0 +1,10 @@
+service=remotebuildexecution.googleapis.com:443
+instance=projects/goma-foundry-experiments/instances/default_instance
+use_application_default_credentials=true
+platform=container-image=docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:f6568d8168b14aafd1b707019927a63c2d37113a03bcee188218f99bd0327ea1,dockerChrootPath=.,dockerRuntime=runsc
+server_address=unix:///tmp/reproxy.sock
+log_path=text:///tmp/reproxy_log.txt
+labels=type=compile,compiler=clang,lang=cpp
+inputs=etc/env.d/05gcc-x86_64-cros-linux-gnu,usr/share/gcc-data/x86_64-pc-linux-gnu/,usr/lib/gcc/x86_64-pc-linux-gnu,usr/x86_64-pc-linux-gnu/,var/cache/chromeos-chrome/chrome-src/src/out_amd64-generic/,bin/bash,bin/cat,usr/lib64/libreadline.so.8,lib64/libc.so.6,lib64/libtinfow.so.5,lib64/ld-linux-x86-64.so.2,usr/bin/x86_64-cros-linux-gnu-clang++,usr/bin/x86_64-cros-linux-gnu-clang,lib64/libpthread.so.0,usr/lib/locale/,usr/bin/clang++,usr/bin/clang,usr/bin/ccache,lib64/libm.so.6,/usr/lib64/libz.so.1,lib64/libdl.so.2,lib64/libtinfo.so.5,usr/lib64/libc++.so.1,usr/lib64/libc++abi.so.1,usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/libgcc_s.so.1,usr/lib/gcc/
+exec_root=/
+env_var_allowlist=PATH


### PR DESCRIPTION
Bug: chromium:1256966
Change-Id: Ibf62439509fe8a91afc5ed3138a12f3d4a38c199
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3279579
Reviewed-by: Ben Pastene <bpastene@chromium.org>
Reviewed-by: Dirk Pranke <dpranke@google.com>
Commit-Queue: Joanna Wang <jojwang@chromium.org>
Cr-Commit-Position: refs/heads/main@{#942746}
NOKEYCHECK=True
GitOrigin-RevId: ac4cfa87de5302d7f805237dc65e7f1f277da8ec